### PR TITLE
Import Sale from the Graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ dmypy.json
 # Temporary files when testing
 /*.csv
 /*.jsonl
+/local_run_files

--- a/tap_decentraland_thegraph/accounts_streams.py
+++ b/tap_decentraland_thegraph/accounts_streams.py
@@ -61,7 +61,7 @@ class PolygonAccountsStream(DecentralandTheGraphCompleteObjectStream):
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
-        return self.config["polygon_api_url"]
+        return self.config["polygon_collections_url"]
 
     primary_keys = ["id"]
     object_returned = 'accounts'

--- a/tap_decentraland_thegraph/client.py
+++ b/tap_decentraland_thegraph/client.py
@@ -150,7 +150,7 @@ class DecentralandTheGraphPolygonStream(DecentralandTheGraphStream):
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
-        return self.config["polygon_api_url"]
+        return self.config["polygon_collections_url"]
 
 
 

--- a/tap_decentraland_thegraph/data/sales.json
+++ b/tap_decentraland_thegraph/data/sales.json
@@ -1,0 +1,19 @@
+{
+    "type": "RECORD",
+    "stream": "sales_ethereum",
+    "record": {"buyer": "069...fea",
+    "feesCollector": "0xadfe...018", 
+    "feesCollectorCut": "1725000000000000000",
+    "id": "7213", 
+    "item": {},
+    "nft": {},
+    "price": "69000000000000000000", 
+    "royaltiesCut": "0",
+    "searchContractAddress": "0xik401..er68", 
+    "searchTokenId": "16426", 
+    "seller": "0xf5295519ad..4b241d",
+    "timestamp": "1588248508", 
+    "txHash": "0xe16ec12..7b704418de8f",
+    "type": "order"},
+    "time_extracted": "2022-01-19T14:40:29.514397Z"
+}

--- a/tap_decentraland_thegraph/sales_streams.py
+++ b/tap_decentraland_thegraph/sales_streams.py
@@ -1,0 +1,126 @@
+"""Stream type classes for tap-decentraland-thegraph."""
+
+import requests, backoff
+from pathlib import Path
+from typing import Any, Dict, Optional, Union, List, Iterable, cast
+
+from singer_sdk import typing as th  # JSON Schema typing helpers
+
+from tap_decentraland_thegraph.client import DecentralandTheGraphCompleteObjectStream
+
+
+class ETHSalesStream(DecentralandTheGraphCompleteObjectStream):
+    name = "sales_ethereum"
+
+    @property
+    def url_base(self) -> str:
+        """Return the API URL root, configurable via tap settings."""
+        return self.config["eth_collections_url"]
+
+    primary_keys = ["id"]
+    object_returned = 'sales'
+    
+    query = """
+    query ($offset: Int!)
+    {
+        sales(
+            first: 1000,
+            skip: $offset,
+            orderBy:timestamp,
+            orderDirection:desc
+        ) {
+            id
+            type
+            buyer
+            seller
+            price
+            feesCollectorCut
+            feesCollector
+            royaltiesCut
+            royaltiesCollector
+            item
+            nft
+            timestamp
+            txHash
+            searchTokenId
+            searchItemId
+            searchContractAddress
+        }
+    }
+    """
+    
+    schema = th.PropertiesList(
+        th.Property("id", th.StringType, required=True),
+        th.Property("type", th.StringType),
+        th.Property("buyer", th.BooleanType),
+        th.Property("seller", th.IntegerType),
+        th.Property("price", th.IntegerType),
+        th.Property("feesCollectorCut", th.IntegerType),
+        th.Property("feesCollector", th.StringType),
+        th.Property("royaltiesCut", th.StringType),
+        th.Property("item", th.StringType),
+        th.Property("nft", th.StringType),
+        th.Property("timestamp", th.StringType),
+        th.Property("txHash", th.StringType),
+        th.Property("searchTokenId", th.StringType),
+        th.Property("searchContractAddress", th.StringType),
+    ).to_dict()
+    
+
+class PolygonSalesStream(DecentralandTheGraphCompleteObjectStream):
+    name = "sales_polygon"
+
+    @property
+    def url_base(self) -> str:
+        """Return the API URL root, configurable via tap settings."""
+        return self.config["polygon_api_url"]
+
+    primary_keys = ["id"]
+    object_returned = 'sales'
+    
+    query = """
+    query ($offset: Int!)
+    {
+        sales(
+            first: 1000,
+            skip: $offset,
+            orderBy:timestamp,
+            orderDirection:desc
+        ) {
+            id
+            type
+            buyer
+            seller
+            price
+            feesCollectorCut
+            feesCollector
+            royaltiesCut
+            royaltiesCollector
+            item
+            nft
+            timestamp
+            txHash
+            searchTokenId
+            searchItemId
+            searchContractAddress
+        }
+    }
+    """
+
+schema = th.PropertiesList(
+        th.Property("id", th.StringType, required=True),
+        th.Property("type", th.StringType),
+        th.Property("buyer", th.BooleanType),
+        th.Property("seller", th.IntegerType),
+        th.Property("price", th.IntegerType),
+        th.Property("feesCollectorCut", th.IntegerType),
+        th.Property("feesCollector", th.StringType),
+        th.Property("royaltiesCut", th.StringType),
+        th.Property("item", th.StringType),
+        th.Property("nft", th.StringType),
+        th.Property("timestamp", th.StringType),
+        th.Property("txHash", th.StringType),
+        th.Property("searchTokenId", th.StringType),
+        th.Property("searchContractAddress", th.StringType),
+    ).to_dict()
+    

--- a/tap_decentraland_thegraph/sales_streams.py
+++ b/tap_decentraland_thegraph/sales_streams.py
@@ -52,10 +52,10 @@ class ETHSalesStream(DecentralandTheGraphCompleteObjectStream):
     schema = th.PropertiesList(
         th.Property("id", th.StringType, required=True),
         th.Property("type", th.StringType),
-        th.Property("buyer", th.BooleanType),
-        th.Property("seller", th.IntegerType),
-        th.Property("price", th.IntegerType),
-        th.Property("feesCollectorCut", th.IntegerType),
+        th.Property("buyer", th.StringType),
+        th.Property("seller", th.StringType),
+        th.Property("price", th.StringType),
+        th.Property("feesCollectorCut", th.StringType),
         th.Property("feesCollector", th.StringType),
         th.Property("royaltiesCut", th.StringType),
         th.Property("item", th.StringType),
@@ -63,7 +63,7 @@ class ETHSalesStream(DecentralandTheGraphCompleteObjectStream):
         th.Property("timestamp", th.StringType),
         th.Property("txHash", th.StringType),
         th.Property("searchTokenId", th.StringType),
-        th.Property("searchContractAddress", th.StringType),
+        th.Property("searchContractAddress", th.StringType)
     ).to_dict()
     
 
@@ -110,10 +110,10 @@ class PolygonSalesStream(DecentralandTheGraphCompleteObjectStream):
 schema = th.PropertiesList(
         th.Property("id", th.StringType, required=True),
         th.Property("type", th.StringType),
-        th.Property("buyer", th.BooleanType),
-        th.Property("seller", th.IntegerType),
-        th.Property("price", th.IntegerType),
-        th.Property("feesCollectorCut", th.IntegerType),
+        th.Property("buyer", th.StringType),
+        th.Property("seller", th.StringType),
+        th.Property("price", th.StringType),
+        th.Property("feesCollectorCut", th.StringType),
         th.Property("feesCollector", th.StringType),
         th.Property("royaltiesCut", th.StringType),
         th.Property("item", th.StringType),
@@ -121,6 +121,5 @@ schema = th.PropertiesList(
         th.Property("timestamp", th.StringType),
         th.Property("txHash", th.StringType),
         th.Property("searchTokenId", th.StringType),
-        th.Property("searchContractAddress", th.StringType),
+        th.Property("searchContractAddress", th.StringType)
     ).to_dict()
-    

--- a/tap_decentraland_thegraph/sales_streams.py
+++ b/tap_decentraland_thegraph/sales_streams.py
@@ -73,7 +73,7 @@ class PolygonSalesStream(DecentralandTheGraphCompleteObjectStream):
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
-        return self.config["polygon_api_url"]
+        return self.config["polygon_collections_url"]
 
     primary_keys = ["id"]
     object_returned = 'sales'
@@ -123,3 +123,6 @@ schema = th.PropertiesList(
         th.Property("searchTokenId", th.StringType),
         th.Property("searchContractAddress", th.StringType)
     ).to_dict()
+
+
+

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -92,6 +92,11 @@ STREAM_TYPES = [
     PolygonSalesStream
 ]
 
+STREAM_TYPES = [
+    ETHSalesStream,
+    PolygonSalesStream
+]
+
 class TapDecentralandTheGraph(Tap):
     """DecentralandTheGraph tap class."""
     name = "tap-decentraland-thegraph"

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -92,11 +92,6 @@ STREAM_TYPES = [
     PolygonSalesStream
 ]
 
-STREAM_TYPES = [
-    ETHSalesStream,
-    PolygonSalesStream
-]
-
 class TapDecentralandTheGraph(Tap):
     """DecentralandTheGraph tap class."""
     name = "tap-decentraland-thegraph"

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -58,6 +58,10 @@ from tap_decentraland_thegraph.accounts_streams import (
     ETHAccountsStream,
     PolygonAccountsStream
 )
+from tap_decentraland_thegraph.sales_streams import ETHSalesStream, PolygonSalesStream (
+    ETHSalesStream,
+    PolygonSalesStream
+)
 
 STREAM_TYPES = [
     WearablesOrdersStream,
@@ -69,8 +73,6 @@ STREAM_TYPES = [
     EstatesStream,
     ParcelsStream,
     NamesStream,
-    WearablesPolygonStream,
-    WearablesBidsStream,
     ParcelsBidsStream,
     EstatesBidsStream,
     EstatesBidsHistoricalStream,
@@ -85,7 +87,9 @@ STREAM_TYPES = [
     PoapsXdai,
     ItemsStream,
     ETHAccountsStream,
-    PolygonAccountsStream
+    PolygonAccountsStream,
+    ETHSalesStream,
+    PolygonSalesStream
 ]
 
 class TapDecentralandTheGraph(Tap):

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -58,7 +58,7 @@ from tap_decentraland_thegraph.accounts_streams import (
     ETHAccountsStream,
     PolygonAccountsStream
 )
-from tap_decentraland_thegraph.sales_streams import ETHSalesStream, PolygonSalesStream (
+from tap_decentraland_thegraph.sales_streams import (
     ETHSalesStream,
     PolygonSalesStream
 )

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -105,7 +105,7 @@ class TapDecentralandTheGraph(Tap):
     config_jsonschema = th.PropertiesList(
         th.Property("start_updated_at", th.IntegerType, default=1),
         th.Property("api_url", th.StringType, default='https://api.thegraph.com/subgraphs/name/decentraland/marketplace'),
-        th.Property("polygon_api_url", th.StringType, default='https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet'),
+        th.Property("polygon_collections_url", th.StringType, default='https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet'),
         th.Property("incremental_limit", th.IntegerType, default=50000),
         th.Property("eth_mana_holder_url", th.StringType, default='https://api.thegraph.com/subgraphs/name/decentraland/mana-ethereum-mainnet'),
         th.Property("polygon_mana_holder_url", th.StringType, default='https://api.thegraph.com/subgraphs/name/decentraland/mana-matic-mainnet'),


### PR DESCRIPTION
This PR adds the tap for the Singer import for the Graph. The sale object consists of 15 fields. All of them are imported as what they exist today. If we need to add new fields that will be done in a new PR.

The PR includes the pull for both [Ethereum](https://thegraph.com/hosted-service/subgraph/decentraland/collections-ethereum-mainnet) and [Polygon](https://thegraph.com/hosted-service/subgraph/decentraland/collections-matic-mainnet) subgraphs