### PR TITLE
Update price to string type

### DIFF
--- a/tap_decentraland_thegraph/nfts_streams_polygon.py
+++ b/tap_decentraland_thegraph/nfts_streams_polygon.py
@@ -1,5 +1,6 @@
 """Stream type classes for tap-decentraland-thegraph."""
 
+from asyncio.windows_events import NULL
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, List, Iterable
 
@@ -236,7 +237,14 @@ class ItemsPolygonStream(DecentralandTheGraphPolygonStream):
         row['totalSupply'] = int(row['totalSupply'])
         row['maxSupply'] = int(row['maxSupply'])
         row['available'] = int(row['available'])
-        row['price'] = int(row['price'])
+        
+        # If Price is a long number null the value
+        # so it doesn't crash when inserting
+        if len(row['price']) > 32:
+            row['price'] = None
+        else:
+            row['price'] = int(row['price'])
+        
         return row
 
     
@@ -253,7 +261,7 @@ class ItemsPolygonStream(DecentralandTheGraphPolygonStream):
         th.Property("maxSupply", th.IntegerType),
         th.Property("rarity", th.StringType),
         th.Property("available", th.IntegerType),
-        th.Property("price", th.StringType),
+        th.Property("price", th.IntegerType),
         th.Property("beneficiary", th.StringType),
         th.Property("contentHash", th.StringType),
         th.Property("URI", th.StringType),

--- a/tap_decentraland_thegraph/nfts_streams_polygon.py
+++ b/tap_decentraland_thegraph/nfts_streams_polygon.py
@@ -1,6 +1,6 @@
 """Stream type classes for tap-decentraland-thegraph."""
 
-from asyncio.windows_events import NULL
+import requests, backoff
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, List, Iterable
 

--- a/tap_decentraland_thegraph/nfts_streams_polygon.py
+++ b/tap_decentraland_thegraph/nfts_streams_polygon.py
@@ -253,7 +253,7 @@ class ItemsPolygonStream(DecentralandTheGraphPolygonStream):
         th.Property("maxSupply", th.IntegerType),
         th.Property("rarity", th.StringType),
         th.Property("available", th.IntegerType),
-        th.Property("price", th.IntegerType),
+        th.Property("price", th.StringType),
         th.Property("beneficiary", th.StringType),
         th.Property("contentHash", th.StringType),
         th.Property("URI", th.StringType),

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -96,6 +96,11 @@ STREAM_TYPES = [
     PolygonSalesStream
 ]
 
+STREAM_TYPES = [
+    ItemsPolygonStream
+
+]
+
 class TapDecentralandTheGraph(Tap):
     """DecentralandTheGraph tap class."""
     name = "tap-decentraland-thegraph"

--- a/tap_decentraland_thegraph/tap.py
+++ b/tap_decentraland_thegraph/tap.py
@@ -96,11 +96,6 @@ STREAM_TYPES = [
     PolygonSalesStream
 ]
 
-STREAM_TYPES = [
-    ItemsPolygonStream
-
-]
-
 class TapDecentralandTheGraph(Tap):
     """DecentralandTheGraph tap class."""
     name = "tap-decentraland-thegraph"


### PR DESCRIPTION
This PR fixes the ongoing issue with long price numbers. Error log: 

`[2022-05-02 07:26:02,271] {ecs.py:324} INFO - [2022-05-02T07:25:34.767000] [2m2022-05-02T07:25:34.766349Z[0m [[32m[1minfo     [0m] [1mtarget_snowflake.exceptions.SnowflakeError: ('Exception writing records', 100038 (22018): Numeric value '5555555555555555555555555555555555000000000000000000' is not recognized[0m [36mcmd_type[0m=[35mloader[0m [36mjob_id[0m=[35mdcl-thegraph-nfts-items-to-snowflake[0m [36mname[0m=[35mtarget-snowflake[0m [36mrun_id[0m=[35mc1c0c4b8-96a2-43f2-afb6-d15d8f6f0074[0m [36mstdio[0m=[35mstderr[0m`